### PR TITLE
Add PHONY target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
+.PHONY: webvr.html
 
 all: webvr.html
 
 webvr.html: webvr.bs
-	curl https://api.csswg.org/bikeshed/ -F file=@webvr.bs -F force=1 > webvr.html 
-
+	curl https://api.csswg.org/bikeshed/ -F file=@webvr.bs -F force=1 > webvr.html


### PR DESCRIPTION
So calling `make` will always run without needing to first call `make clean`.
